### PR TITLE
#50: Equivalence-base is now compiled as multi-release jar with module-info inside

### DIFF
--- a/build-tools/parent/pom.xml
+++ b/build-tools/parent/pom.xml
@@ -16,7 +16,7 @@
     <profiles>
 
         <profile>
-            <id>compile-java9</id>
+            <id>multi-release-java9</id>
             <activation>
                 <file>
                     <exists>src/main/java9</exists>
@@ -42,6 +42,17 @@
                                 </configuration>
                             </execution>
                         </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <configuration>
+                            <archive>
+                                <manifestEntries>
+                                    <Multi-Release>true</Multi-Release>
+                                </manifestEntries>
+                            </archive>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/build-tools/parent/pom.xml
+++ b/build-tools/parent/pom.xml
@@ -14,6 +14,38 @@
     <packaging>pom</packaging>
 
     <profiles>
+
+        <profile>
+            <id>compile-java9</id>
+            <activation>
+                <file>
+                    <exists>src/main/java9</exists>
+                </file>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>compile-java9</id>
+                                <goals>
+                                    <goal>compile</goal>
+                                </goals>
+                                <configuration>
+                                    <release>9</release>
+                                    <compileSourceRoots>
+                                        <compileSourceRoot>${project.basedir}/src/main/java9</compileSourceRoot>
+                                    </compileSourceRoots>
+                                    <multiReleaseOutput>true</multiReleaseOutput>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>tests</id>
             <activation>

--- a/oo-equivalence/equivalence-base/src/main/java9/module-info.java
+++ b/oo-equivalence/equivalence-base/src/main/java9/module-info.java
@@ -23,6 +23,7 @@
  * THE SOFTWARE.
  * ============================================================================
  */
-module equivalence.base {
-
+module com.pragmaticobjects.oo.equivalence.base {
+    requires java.base;
+    exports com.pragmaticobjects.oo.equivalence.base;
 }

--- a/oo-equivalence/equivalence-base/src/main/java9/module-info.java
+++ b/oo-equivalence/equivalence-base/src/main/java9/module-info.java
@@ -1,0 +1,28 @@
+/*-
+ * ===========================================================================
+ * equivalence-base
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * Copyright (C) 2019 - 2023 Kapralov Sergey
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * ============================================================================
+ */
+module equivalence.base {
+
+}

--- a/oo-equivalence/equivalence-codegen/src/main/java/com/pragmaticobjects/oo/equivalence/codegen/cn/CnFromPath.java
+++ b/oo-equivalence/equivalence-codegen/src/main/java/com/pragmaticobjects/oo/equivalence/codegen/cn/CnFromPath.java
@@ -60,7 +60,7 @@ public class CnFromPath implements ClassNames {
                 .map(p -> List.ofAll(StreamSupport.stream(p.spliterator(), false)))
                 .map(pl -> pl.map(Object::toString).collect(Collectors.joining(".")))
                 .map(s -> s.replaceFirst(".class$", ""))
-                .filter(s -> !"module-info".equals(s))
+                .filter(s -> !s.endsWith("module-info"))
                 .collect(List.collector());
             return classes;
         } catch(Exception ex) {

--- a/oo-equivalence/equivalence-codegen/src/test/java/com/pragmaticobjects/oo/equivalence/codegen/cn/CnFromPathTest.java
+++ b/oo-equivalence/equivalence-codegen/src/test/java/com/pragmaticobjects/oo/equivalence/codegen/cn/CnFromPathTest.java
@@ -63,6 +63,15 @@ public class CnFromPathTest extends TestsSuite {
                     ),
                     Paths.get("module-info.class")
                 )
+            ),
+            new TestCase(
+                "ignores module-info.class in multi-release project",
+                new AssertSimulatingClasspath(
+                    path -> new AssertZeroClassNames(
+                        new CnFromPath(path)
+                    ),
+                    Paths.get("META-INF/versions/9/module-info.class")
+                )
             )
         );
     }


### PR DESCRIPTION
Closes #50 