### PR TITLE
docs: add Javadoc to all interfaces and classes across the project

### DIFF
--- a/oo-equivalence/equivalence-assertions/src/main/java/com/pragmaticobjects/oo/equivalence/assertions/AssertImplements.java
+++ b/oo-equivalence/equivalence-assertions/src/main/java/com/pragmaticobjects/oo/equivalence/assertions/AssertImplements.java
@@ -31,17 +31,36 @@ import org.assertj.core.api.Assertions;
 import java.lang.reflect.Type;
 import java.util.stream.Collectors;
 
+/**
+ * Assertion that passes when a given class implements (or is assignable to) a specified interface.
+ * Supports both shallow (direct interfaces only) and deep (full type hierarchy) search.
+ *
+ * @author Kapralov Sergey
+ */
 public class AssertImplements implements Assertion {
     private final Class<?> source;
     private final Class<?> typeName;
     private final boolean deepSearch;
 
+    /**
+     * Ctor.
+     *
+     * @param source     the class to inspect
+     * @param typeName   the interface the class is expected to implement
+     * @param deepSearch {@code true} to search the full type hierarchy; {@code false} for direct interfaces only
+     */
     public AssertImplements(Class<?> source, Class<?> typeName, boolean deepSearch) {
         this.source = source;
         this.typeName = typeName;
         this.deepSearch = deepSearch;
     }
 
+    /**
+     * Ctor. Uses shallow search (direct interfaces only).
+     *
+     * @param source   the class to inspect
+     * @param typeName the interface the class is expected to implement
+     */
     public AssertImplements(Class<?> source, Class<?> typeName) {
         this(source, typeName, false);
     }

--- a/oo-equivalence/equivalence-assertions/src/main/java/com/pragmaticobjects/oo/equivalence/assertions/AssertImplementsTypeName.java
+++ b/oo-equivalence/equivalence-assertions/src/main/java/com/pragmaticobjects/oo/equivalence/assertions/AssertImplementsTypeName.java
@@ -31,10 +31,22 @@ import org.assertj.core.api.Assertions;
 import java.lang.reflect.Type;
 import java.util.stream.Collectors;
 
+/**
+ * Assertion that passes when a given class directly implements an interface identified by its
+ * fully-qualified type name string.
+ *
+ * @author Kapralov Sergey
+ */
 public class AssertImplementsTypeName implements Assertion {
     private final Class<?> source;
     private final String typeName;
 
+    /**
+     * Ctor.
+     *
+     * @param source   the class to inspect
+     * @param typeName the fully-qualified name of the interface the class is expected to implement
+     */
     public AssertImplementsTypeName(Class<?> source, String typeName) {
         this.source = source;
         this.typeName = typeName;

--- a/oo-equivalence/equivalence-base/src/main/java/com/pragmaticobjects/oo/equivalence/base/EObjectHint.java
+++ b/oo-equivalence/equivalence-base/src/main/java/com/pragmaticobjects/oo/equivalence/base/EObjectHint.java
@@ -58,5 +58,11 @@ import java.lang.annotation.Target;
 @Target({ElementType.TYPE, ElementType.PACKAGE})
 @Retention(RetentionPolicy.CLASS)
 public @interface EObjectHint {
+    /**
+     * Whether the hint is enabled.
+     * Set to {@code false} to explicitly exclude a class from instrumentation.
+     *
+     * @return {@code true} by default
+     */
     boolean enabled() default true;
 }

--- a/oo-equivalence/equivalence-base/src/main/java/com/pragmaticobjects/oo/equivalence/base/EquivalenceCompliant.java
+++ b/oo-equivalence/equivalence-base/src/main/java/com/pragmaticobjects/oo/equivalence/base/EquivalenceCompliant.java
@@ -32,5 +32,11 @@ package com.pragmaticobjects.oo.equivalence.base;
  * or use {@link NaturallyEquivalent} decorator
  */
 public interface EquivalenceCompliant {
+    /**
+     * Returns whether instances of this class participate in equivalence checks
+     * (i.e., can be reliably compared via {@code equals} and {@code hashCode}).
+     *
+     * @return {@code true} if equivalence checks are applicable to this instance
+     */
     boolean isEquivalenceCompliant();
 }

--- a/oo-equivalence/equivalence-base/src/main/java/com/pragmaticobjects/oo/equivalence/base/EquivalenceHint.java
+++ b/oo-equivalence/equivalence-base/src/main/java/com/pragmaticobjects/oo/equivalence/base/EquivalenceHint.java
@@ -42,6 +42,17 @@ import java.lang.annotation.Target;
 @Target({ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface EquivalenceHint {
+    /**
+     * Whether equivalence check is enabled for this field.
+     *
+     * @return {@code true} by default
+     */
     boolean enabled() default true;
+
+    /**
+     * The {@link ToStringMethod} strategy to use for this field's string representation.
+     *
+     * @return {@link Default} strategy by default
+     */
     Class<? extends ToStringMethod> toStringMethod() default Default.class;
 }

--- a/oo-equivalence/equivalence-base/src/main/java/com/pragmaticobjects/oo/equivalence/base/EquivalenceLogic.java
+++ b/oo-equivalence/equivalence-base/src/main/java/com/pragmaticobjects/oo/equivalence/base/EquivalenceLogic.java
@@ -31,9 +31,24 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+/**
+ * Static utility class that implements {@code equals}, {@code hashCode}, and {@code toString}
+ * logic for {@link EObject} instances. All {@link EObject} implementors must delegate
+ * those methods to this class.
+ *
+ * @author Kapralov Sergey
+ */
 public class EquivalenceLogic {
     private static final boolean FIXED_STATIC_IDENTITY = System.getProperty("fixedStaticIdentity") != null;
 
+    /**
+     * Implements equality check for {@link EObject} instances by comparing their base types
+     * and attributes pairwise.
+     *
+     * @param that the object on which {@code equals} was called
+     * @param obj  the object to compare with
+     * @return {@code true} if both objects have the same base type and all attributes are equal
+     */
     public static boolean equals(EObject that, Object obj) {
         if (that == obj) {
             return true;
@@ -58,6 +73,12 @@ public class EquivalenceLogic {
         return false;
     }
 
+    /**
+     * Computes a hash code for an {@link EObject} using its hash seed and attributes.
+     *
+     * @param that the object whose hash code is being computed
+     * @return the computed hash code
+     */
     public static int hashCode(EObject that) {
         final Object[] attrs = that.attributes();
         final int hashSeed = that.hashSeed();
@@ -68,6 +89,13 @@ public class EquivalenceLogic {
         return result;
     }
 
+    /**
+     * Produces a human-readable string representation of an {@link EObject}, listing its
+     * simple class name and all attribute values.
+     *
+     * @param that the object to stringify
+     * @return string representation in the form {@code ClassName(attr1, attr2, ...)}
+     */
     public static String toString(EObject that) {
         final Object[] attrs = that.attributes();
         StringBuilder sb = new StringBuilder();

--- a/oo-equivalence/equivalence-base/src/main/java/com/pragmaticobjects/oo/equivalence/base/HintedAttribute.java
+++ b/oo-equivalence/equivalence-base/src/main/java/com/pragmaticobjects/oo/equivalence/base/HintedAttribute.java
@@ -29,11 +29,24 @@ import com.pragmaticobjects.oo.equivalence.base.tostring.ToStringMethod;
 
 import java.util.Objects;
 
+/**
+ * Wrapper for an object attribute that attaches a custom {@link ToStringMethod} strategy
+ * and controls whether the attribute participates in equivalence checks.
+ *
+ * @author Kapralov Sergey
+ */
 public class HintedAttribute implements EquivalenceCompliant {
     private final Object obj;
     private final ToStringMethod stringifyMethod;
     private final boolean equivalenceCompliant;
 
+    /**
+     * Ctor.
+     *
+     * @param obj                  the wrapped attribute value
+     * @param stringifyMethod      strategy used to produce the string representation
+     * @param equivalenceCompliant whether this attribute participates in equals/hashCode checks
+     */
     public HintedAttribute(Object obj, ToStringMethod stringifyMethod, boolean equivalenceCompliant) {
         this.obj = obj;
         this.stringifyMethod = stringifyMethod;

--- a/oo-equivalence/equivalence-base/src/main/java/com/pragmaticobjects/oo/equivalence/base/NaturallyEquivalent.java
+++ b/oo-equivalence/equivalence-base/src/main/java/com/pragmaticobjects/oo/equivalence/base/NaturallyEquivalent.java
@@ -34,6 +34,11 @@ import com.pragmaticobjects.oo.equivalence.base.tostring.ToStringMethod;
 public class NaturallyEquivalent extends HintedAttribute {
     private static final ToStringMethod DEFAULT = new Default();
 
+    /**
+     * Ctor.
+     *
+     * @param obj the object to wrap and mark as equivalence-compliant
+     */
     public NaturallyEquivalent(Object obj) {
         super(
             obj,

--- a/oo-equivalence/equivalence-base/src/main/java/com/pragmaticobjects/oo/equivalence/base/tostring/Default.java
+++ b/oo-equivalence/equivalence-base/src/main/java/com/pragmaticobjects/oo/equivalence/base/tostring/Default.java
@@ -28,6 +28,13 @@ package com.pragmaticobjects.oo.equivalence.base.tostring;
 import com.pragmaticobjects.oo.equivalence.base.EObject;
 import com.pragmaticobjects.oo.equivalence.base.EquivalenceLogic;
 
+/**
+ * Default {@link ToStringMethod} that delegates to {@link com.pragmaticobjects.oo.equivalence.base.EquivalenceLogic#toString}
+ * for {@link com.pragmaticobjects.oo.equivalence.base.EObject} instances, and to
+ * {@link Object#toString()} for all other types.
+ *
+ * @author Kapralov Sergey
+ */
 public class Default implements ToStringMethod {
     @Override
     public final String stringify(Object obj) {

--- a/oo-equivalence/equivalence-base/src/main/java/com/pragmaticobjects/oo/equivalence/base/tostring/Hex.java
+++ b/oo-equivalence/equivalence-base/src/main/java/com/pragmaticobjects/oo/equivalence/base/tostring/Hex.java
@@ -25,15 +25,29 @@
  */
 package com.pragmaticobjects.oo.equivalence.base.tostring;
 
+/**
+ * {@link ToStringMethod} that formats numeric values as hexadecimal strings.
+ * Non-numeric objects fall back to the {@link Default} strategy.
+ *
+ * @author Kapralov Sergey
+ */
 public class Hex implements ToStringMethod {
     private static final ToStringMethod DEFAULT = new Default();
 
     private final String prefix;
 
+    /**
+     * Ctor.
+     *
+     * @param prefix prefix to prepend to the hex string (e.g. {@code "0x"})
+     */
     public Hex(String prefix) {
         this.prefix = prefix;
     }
 
+    /**
+     * Ctor. Uses the default prefix {@code "0x"}.
+     */
     public Hex() {
         this("0x");
     }

--- a/oo-equivalence/equivalence-base/src/main/java/com/pragmaticobjects/oo/equivalence/base/tostring/Hide.java
+++ b/oo-equivalence/equivalence-base/src/main/java/com/pragmaticobjects/oo/equivalence/base/tostring/Hide.java
@@ -25,9 +25,20 @@
  */
 package com.pragmaticobjects.oo.equivalence.base.tostring;
 
+/**
+ * {@link ToStringMethod} that replaces the attribute value with a fixed stub string,
+ * effectively hiding the actual value from the {@code toString} output.
+ *
+ * @author Kapralov Sergey
+ */
 public class Hide implements ToStringMethod {
     private final String stub;
 
+    /**
+     * Ctor.
+     *
+     * @param stub the fixed string to use instead of the actual attribute value
+     */
     public Hide(String stub) {
         this.stub = stub;
     }

--- a/oo-equivalence/equivalence-base/src/main/java/com/pragmaticobjects/oo/equivalence/base/tostring/Iterating.java
+++ b/oo-equivalence/equivalence-base/src/main/java/com/pragmaticobjects/oo/equivalence/base/tostring/Iterating.java
@@ -30,12 +30,26 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.StreamSupport;
 
+/**
+ * {@link ToStringMethod} that iterates over array or {@link Iterable} attribute values,
+ * applying a delegate strategy to each element and joining the results.
+ *
+ * @author Kapralov Sergey
+ */
 public class Iterating implements ToStringMethod {
     private final ToStringMethod methodForEachItem;
     private final String start;
     private final String end;
     private final String separator;
 
+    /**
+     * Ctor.
+     *
+     * @param methodForEachItem strategy applied to each element
+     * @param start             opening bracket string (e.g. {@code "["})
+     * @param end               closing bracket string (e.g. {@code "]"})
+     * @param separator         delimiter between elements (e.g. {@code ", "})
+     */
     public Iterating(ToStringMethod methodForEachItem, String start, String end, String separator) {
         this.methodForEachItem = methodForEachItem;
         this.start = start;
@@ -43,6 +57,11 @@ public class Iterating implements ToStringMethod {
         this.separator = separator;
     }
 
+    /**
+     * Ctor. Uses default brackets {@code "["} / {@code "]"} and separator {@code ", "}.
+     *
+     * @param methodForEachItem strategy applied to each element
+     */
     public Iterating(ToStringMethod methodForEachItem) {
         this(
             methodForEachItem,

--- a/oo-equivalence/equivalence-base/src/main/java/com/pragmaticobjects/oo/equivalence/base/tostring/Stub.java
+++ b/oo-equivalence/equivalence-base/src/main/java/com/pragmaticobjects/oo/equivalence/base/tostring/Stub.java
@@ -25,7 +25,16 @@
  */
 package com.pragmaticobjects.oo.equivalence.base.tostring;
 
+/**
+ * {@link ToStringMethod} that always outputs {@code "..."}, indicating that
+ * the actual attribute value is intentionally omitted from the {@code toString} representation.
+ *
+ * @author Kapralov Sergey
+ */
 public class Stub extends Hide {
+    /**
+     * Ctor.
+     */
     public Stub() {
         super("...");
     }

--- a/oo-equivalence/equivalence-base/src/main/java/com/pragmaticobjects/oo/equivalence/base/tostring/ToStringMethod.java
+++ b/oo-equivalence/equivalence-base/src/main/java/com/pragmaticobjects/oo/equivalence/base/tostring/ToStringMethod.java
@@ -25,6 +25,19 @@
  */
 package com.pragmaticobjects.oo.equivalence.base.tostring;
 
+/**
+ * Strategy interface for producing a string representation of an object attribute.
+ * Implementations are used by {@link com.pragmaticobjects.oo.equivalence.base.HintedAttribute}
+ * to customise how individual fields appear in {@code toString} output.
+ *
+ * @author Kapralov Sergey
+ */
 public interface ToStringMethod {
+    /**
+     * Converts the given object to its string representation.
+     *
+     * @param obj the object to stringify
+     * @return string representation of {@code obj}
+     */
     String stringify(Object obj);
 }

--- a/oo-equivalence/equivalence-codegen/src/main/java/com/pragmaticobjects/oo/equivalence/codegen/ii/IIImplementEObjectEquals.java
+++ b/oo-equivalence/equivalence-codegen/src/main/java/com/pragmaticobjects/oo/equivalence/codegen/ii/IIImplementEObjectEquals.java
@@ -44,6 +44,13 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Method;
 
+/**
+ * Instrumentation iteration that generates a bytecode {@code equals(Object)} implementation
+ * for {@link com.pragmaticobjects.oo.equivalence.base.EObject} candidates, delegating to
+ * {@link com.pragmaticobjects.oo.equivalence.base.EquivalenceLogic#equals}.
+ *
+ * @author Kapralov Sergey
+ */
 public class IIImplementEObjectEquals implements InstrumentationIteration {
     private static final Logger log = LoggerFactory.getLogger(IIImplementEObjectEquals.class);
     private static final Method EQLOGIC_EQUALS;

--- a/oo-equivalence/equivalence-codegen/src/main/java/com/pragmaticobjects/oo/equivalence/codegen/ii/IIImplementEObjectHashCode.java
+++ b/oo-equivalence/equivalence-codegen/src/main/java/com/pragmaticobjects/oo/equivalence/codegen/ii/IIImplementEObjectHashCode.java
@@ -44,6 +44,13 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Method;
 
+/**
+ * Instrumentation iteration that generates a bytecode {@code hashCode()} implementation
+ * for {@link com.pragmaticobjects.oo.equivalence.base.EObject} candidates, delegating to
+ * {@link com.pragmaticobjects.oo.equivalence.base.EquivalenceLogic#hashCode}.
+ *
+ * @author Kapralov Sergey
+ */
 public class IIImplementEObjectHashCode implements InstrumentationIteration {
     private static final Logger log = LoggerFactory.getLogger(IIImplementEObjectHashCode.class);
     private static final Method EQLOGIC_HASHCODE;

--- a/oo-equivalence/equivalence-codegen/src/main/java/com/pragmaticobjects/oo/equivalence/codegen/ii/IIImplementEObjectToString.java
+++ b/oo-equivalence/equivalence-codegen/src/main/java/com/pragmaticobjects/oo/equivalence/codegen/ii/IIImplementEObjectToString.java
@@ -44,6 +44,13 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Method;
 
+/**
+ * Instrumentation iteration that generates a bytecode {@code toString()} implementation
+ * for {@link com.pragmaticobjects.oo.equivalence.base.EObject} candidates, delegating to
+ * {@link com.pragmaticobjects.oo.equivalence.base.EquivalenceLogic#toString}.
+ *
+ * @author Kapralov Sergey
+ */
 public class IIImplementEObjectToString implements InstrumentationIteration {
     private static final Logger log = LoggerFactory.getLogger(IIImplementEObjectToString.class);
     private static final Method EQLOGIC_TOSTRING;

--- a/oo-equivalence/equivalence-itests/test-module2/src/main/java/com/pragmaticobjects/oo/equivalence/itests/classes/GenericsTest.java
+++ b/oo-equivalence/equivalence-itests/test-module2/src/main/java/com/pragmaticobjects/oo/equivalence/itests/classes/GenericsTest.java
@@ -29,6 +29,12 @@ package com.pragmaticobjects.oo.equivalence.itests.classes;
 import io.vavr.collection.Map;
 
 
+/**
+ * Test fixture class implementing {@link GenericsTestIface} with a concrete generic argument,
+ * used to verify instrumentation of classes with generic interfaces.
+ *
+ * @author Kapralov Sergey
+ */
 public class GenericsTest implements GenericsTestIface<Map<String, Object>> {
     @Override
     public final Map<String, Object> get() {

--- a/oo-equivalence/equivalence-itests/test-module2/src/main/java/com/pragmaticobjects/oo/equivalence/itests/classes/GenericsTestIface.java
+++ b/oo-equivalence/equivalence-itests/test-module2/src/main/java/com/pragmaticobjects/oo/equivalence/itests/classes/GenericsTestIface.java
@@ -25,6 +25,16 @@
  */
 package com.pragmaticobjects.oo.equivalence.itests.classes;
 
+/**
+ * Test fixture interface with a single generic return method,
+ * used to verify that the instrumentor handles generic types correctly.
+ *
+ * @param <T> the type produced by {@link #get()}
+ * @author Kapralov Sergey
+ */
 public interface GenericsTestIface<T> {
+    /**
+     * @return a value of type {@code T}
+     */
     T get();
 }

--- a/oo-equivalence/equivalence-itests/test-module2/src/main/java/com/pragmaticobjects/oo/equivalence/itests/classes/PublicPoint.java
+++ b/oo-equivalence/equivalence-itests/test-module2/src/main/java/com/pragmaticobjects/oo/equivalence/itests/classes/PublicPoint.java
@@ -25,10 +25,24 @@
  */
 package com.pragmaticobjects.oo.equivalence.itests.classes;
 
+/**
+ * Test fixture representing a 2D point with public final fields,
+ * used to verify instrumentation of classes with public fields.
+ *
+ * @author Kapralov Sergey
+ */
 public class PublicPoint {
+    /** X coordinate. */
     public final int x;
+    /** Z coordinate. */
     public final int z;
 
+    /**
+     * Ctor.
+     *
+     * @param x x coordinate
+     * @param z z coordinate
+     */
     public PublicPoint(int x, int z) {
         this.x = x;
         this.z = z;

--- a/oo-equivalence/equivalence-itests/test-module2/src/main/java/com/pragmaticobjects/oo/equivalence/itests/classes/TimeRange.java
+++ b/oo-equivalence/equivalence-itests/test-module2/src/main/java/com/pragmaticobjects/oo/equivalence/itests/classes/TimeRange.java
@@ -29,10 +29,24 @@ import com.pragmaticobjects.oo.equivalence.base.EquivalenceHint;
 
 import java.time.LocalDate;
 
+/**
+ * Test fixture representing a date range with {@link EquivalenceHint}-annotated fields,
+ * used to verify instrumentation of classes that use the field-level equivalence hint.
+ *
+ * @author Kapralov Sergey
+ */
 public class TimeRange {
+    /** Start date (equivalence-hint enabled). */
     public final @EquivalenceHint(enabled = true) LocalDate beginDate;
+    /** End date (equivalence-hint enabled). */
     public final @EquivalenceHint(enabled = true) LocalDate endDate;
 
+    /**
+     * Ctor.
+     *
+     * @param beginDate start of the range
+     * @param endDate   end of the range
+     */
     public TimeRange(LocalDate beginDate, LocalDate endDate) {
         this.beginDate = beginDate;
         this.endDate = endDate;

--- a/oo-equivalence/equivalence-itests/test-module2/src/main/java/com/pragmaticobjects/oo/equivalence/itests/fieldlevelhint/HexHint.java
+++ b/oo-equivalence/equivalence-itests/test-module2/src/main/java/com/pragmaticobjects/oo/equivalence/itests/fieldlevelhint/HexHint.java
@@ -28,6 +28,12 @@ package com.pragmaticobjects.oo.equivalence.itests.fieldlevelhint;
 import com.pragmaticobjects.oo.equivalence.base.EquivalenceHint;
 import com.pragmaticobjects.oo.equivalence.base.tostring.Hex;
 
+/**
+ * Test fixture with multiple fields annotated with {@link com.pragmaticobjects.oo.equivalence.base.EquivalenceHint}
+ * using {@link Hex} as the toString strategy, covering all supported primitive and string types.
+ *
+ * @author Kapralov Sergey
+ */
 public class HexHint {
     private final int ref;
     private final @EquivalenceHint(toStringMethod = Hex.class) int ref2;
@@ -38,6 +44,18 @@ public class HexHint {
     private final @EquivalenceHint(toStringMethod = Hex.class) long ref7;
     private final @EquivalenceHint(toStringMethod = Hex.class) String ref8;
 
+    /**
+     * Ctor.
+     *
+     * @param ref   plain int field
+     * @param ref2  int rendered as hex
+     * @param ref3  short rendered as hex
+     * @param ref4  char rendered as hex
+     * @param ref5  byte rendered as hex
+     * @param ref6  boolean rendered as hex
+     * @param ref7  long rendered as hex
+     * @param ref8  String rendered as hex
+     */
     public HexHint(int ref, int ref2, short ref3, char ref4, byte ref5, boolean ref6, long ref7, String ref8) {
         this.ref = ref;
         this.ref2 = ref2;

--- a/oo-equivalence/equivalence-itests/test-module2/src/main/java/com/pragmaticobjects/oo/equivalence/itests/fieldlevelhint/HexedIterable.java
+++ b/oo-equivalence/equivalence-itests/test-module2/src/main/java/com/pragmaticobjects/oo/equivalence/itests/fieldlevelhint/HexedIterable.java
@@ -28,7 +28,15 @@ package com.pragmaticobjects.oo.equivalence.itests.fieldlevelhint;
 import com.pragmaticobjects.oo.equivalence.base.tostring.Hex;
 import com.pragmaticobjects.oo.equivalence.base.tostring.Iterating;
 
+/**
+ * Test-fixture {@link Iterating} strategy that formats each element using {@link Hex}.
+ *
+ * @author Kapralov Sergey
+ */
 public class HexedIterable extends Iterating {
+    /**
+     * Ctor.
+     */
     public HexedIterable() {
         super(new Hex());
     }

--- a/oo-equivalence/equivalence-itests/test-module2/src/main/java/com/pragmaticobjects/oo/equivalence/itests/fieldlevelhint/IterableHexes.java
+++ b/oo-equivalence/equivalence-itests/test-module2/src/main/java/com/pragmaticobjects/oo/equivalence/itests/fieldlevelhint/IterableHexes.java
@@ -28,6 +28,12 @@ package com.pragmaticobjects.oo.equivalence.itests.fieldlevelhint;
 import com.pragmaticobjects.oo.equivalence.base.EquivalenceHint;
 import io.vavr.collection.List;
 
+/**
+ * Test fixture class with array and {@link io.vavr.collection.List} fields annotated to use
+ * {@link HexedIterable} as the toString strategy, used to verify iterable hex rendering.
+ *
+ * @author Kapralov Sergey
+ */
 public class IterableHexes {
     private static final int[] REF_ARRAY = new int[] {1, 2, 3};
     private static final List<Integer> REF_LIST = List.of(1, 2, 3);
@@ -35,11 +41,20 @@ public class IterableHexes {
     private final @EquivalenceHint(enabled = false, toStringMethod = HexedIterable.class) int[] refArray;
     private final @EquivalenceHint(enabled = false, toStringMethod = HexedIterable.class) List<Integer> refList;
 
+    /**
+     * Ctor.
+     *
+     * @param refArray int array rendered with {@link HexedIterable}
+     * @param refList  integer list rendered with {@link HexedIterable}
+     */
     public IterableHexes(int[] refArray, List<Integer> refList) {
         this.refArray = refArray;
         this.refList = refList;
     }
 
+    /**
+     * Ctor. Uses default reference values.
+     */
     public IterableHexes() {
         this(
             REF_ARRAY,

--- a/oo-equivalence/equivalence-itests/test-module2/src/main/java/com/pragmaticobjects/oo/equivalence/itests/fieldlevelhint/StubHint.java
+++ b/oo-equivalence/equivalence-itests/test-module2/src/main/java/com/pragmaticobjects/oo/equivalence/itests/fieldlevelhint/StubHint.java
@@ -28,12 +28,24 @@ package com.pragmaticobjects.oo.equivalence.itests.fieldlevelhint;
 import com.pragmaticobjects.oo.equivalence.base.EquivalenceHint;
 import com.pragmaticobjects.oo.equivalence.base.tostring.Stub;
 
+/**
+ * Test fixture class with a field annotated to use {@link com.pragmaticobjects.oo.equivalence.base.tostring.Stub}
+ * as the toString strategy, verifying that hidden field values appear as {@code "..."} in output.
+ *
+ * @author Kapralov Sergey
+ */
 public class StubHint {
     private final String ref;
     private final @EquivalenceHint(
         toStringMethod = Stub.class
     ) String ref2;
 
+    /**
+     * Ctor.
+     *
+     * @param ref  the first (visible) string field
+     * @param ref2 the second (stubbed) string field
+     */
     public StubHint(String ref, String ref2) {
         this.ref = ref;
         this.ref2 = ref2;

--- a/oo-equivalence/equivalence-itests/test-module2/src/main/java/com/pragmaticobjects/oo/equivalence/itests/packagelevelhint/SimpleClass.java
+++ b/oo-equivalence/equivalence-itests/test-module2/src/main/java/com/pragmaticobjects/oo/equivalence/itests/packagelevelhint/SimpleClass.java
@@ -25,12 +25,25 @@
  */
 package com.pragmaticobjects.oo.equivalence.itests.packagelevelhint;
 
+/**
+ * Test fixture class used to verify package-level {@link com.pragmaticobjects.oo.equivalence.base.EObjectHint}
+ * instrumentation. Intentionally contains a non-final method to confirm that the instrumentor
+ * can handle such classes when the package hint is in effect.
+ *
+ * @author Kapralov Sergey
+ */
 public class SimpleClass {
     private final int a;
 
+    /**
+     * Ctor.
+     *
+     * @param a the integer value held by this object
+     */
     public SimpleClass(int a) {
         this.a = a;
     }
 
+    /** Non-final method present to test instrumentation behaviour with package-level hints. */
     public void nonFinalMethodThatUsuallyFailsTheInstrumentation() {}
 }

--- a/oo-guidelines/guidelines-archunit/src/main/java/com/pragmaticobjects/oo/guidelines/archunit/archunit/assertions/AssertThatAllConstructorsOfConcreticsAreEitherPrimaryOrSecondary.java
+++ b/oo-guidelines/guidelines-archunit/src/main/java/com/pragmaticobjects/oo/guidelines/archunit/archunit/assertions/AssertThatAllConstructorsOfConcreticsAreEitherPrimaryOrSecondary.java
@@ -40,7 +40,24 @@ import static com.tngtech.archunit.base.DescribedPredicate.not;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.*;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.constructors;
 
+/**
+ * Assertion that enforces the guideline that every constructor of a concrete class must be either
+ * a <em>primary constructor</em> (sets final fields, calls super) or a
+ * <em>secondary constructor</em> (delegates to another constructor without field assignments).
+ *
+ * @author Kapralov Sergey
+ */
 public class AssertThatAllConstructorsOfConcreticsAreEitherPrimaryOrSecondary extends AssertThatClassesFollowProvidedArchunitGuidelines {
+    /**
+     * Ctor.
+     *
+     * @param javaClasses                                       classes to check
+     * @param concretics                                        predicate identifying the concrete classes to enforce the rule on
+     * @param fieldAccessExclusionsAllowedInPrimaryConstructor  additional field-access patterns that are allowed in primary constructors
+     * @param callsAllowedInPrimaryConstructor                  additional constructor-call patterns that are allowed in primary constructors
+     * @param fieldAccessExclusionsAllowedInSecondaryConstructor additional field-access patterns that are allowed in secondary constructors
+     * @param callsAllowedInSecondaryConstructor                additional constructor-call patterns that are allowed in secondary constructors
+     */
     public AssertThatAllConstructorsOfConcreticsAreEitherPrimaryOrSecondary(
         JavaClasses javaClasses,
         DescribedPredicate<JavaClass> concretics,
@@ -77,6 +94,12 @@ public class AssertThatAllConstructorsOfConcreticsAreEitherPrimaryOrSecondary ex
         );
     }
 
+    /**
+     * Ctor. Uses empty exclusion lists (no additional exclusions).
+     *
+     * @param javaClasses classes to check
+     * @param concretics  predicate identifying the concrete classes to enforce the rule on
+     */
     public AssertThatAllConstructorsOfConcreticsAreEitherPrimaryOrSecondary(
         JavaClasses javaClasses,
         DescribedPredicate<JavaClass> concretics

--- a/oo-guidelines/guidelines-archunit/src/main/java/com/pragmaticobjects/oo/guidelines/archunit/archunit/assertions/AssertThatAllNonAbstractMethodsOfConcreteClassesAreFinal.java
+++ b/oo-guidelines/guidelines-archunit/src/main/java/com/pragmaticobjects/oo/guidelines/archunit/archunit/assertions/AssertThatAllNonAbstractMethodsOfConcreteClassesAreFinal.java
@@ -39,7 +39,19 @@ import static com.tngtech.archunit.core.domain.JavaModifier.ABSTRACT;
 import static com.tngtech.archunit.core.domain.properties.HasModifiers.Predicates.modifier;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
 
+/**
+ * Assertion that enforces the guideline that all non-abstract, non-static, non-private methods
+ * of concrete classes must be declared {@code final}.
+ *
+ * @author Kapralov Sergey
+ */
 public class AssertThatAllNonAbstractMethodsOfConcreteClassesAreFinal extends AssertThatClassesFollowProvidedArchunitGuidelines {
+    /**
+     * Ctor.
+     *
+     * @param javaClasses classes to check
+     * @param concretics  predicate identifying the concrete classes to enforce the rule on
+     */
     public AssertThatAllNonAbstractMethodsOfConcreteClassesAreFinal(
         JavaClasses javaClasses,
         DescribedPredicate<JavaClass> concretics

--- a/oo-guidelines/guidelines-archunit/src/main/java/com/pragmaticobjects/oo/guidelines/archunit/archunit/assertions/AssertThatClassesFollowProvidedArchunitGuidelines.java
+++ b/oo-guidelines/guidelines-archunit/src/main/java/com/pragmaticobjects/oo/guidelines/archunit/archunit/assertions/AssertThatClassesFollowProvidedArchunitGuidelines.java
@@ -29,10 +29,23 @@ import com.pragmaticobjects.oo.tests.Assertion;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.lang.ArchRule;
 
+/**
+ * Base assertion that bridges between the oo-tests {@link Assertion} abstraction and an
+ * ArchUnit {@link ArchRule}. Subclasses configure the rule in their constructor and this class
+ * executes it against a provided set of {@link JavaClasses}.
+ *
+ * @author Kapralov Sergey
+ */
 public class AssertThatClassesFollowProvidedArchunitGuidelines implements Assertion {
     private final ArchRule archunitRule;
     private final JavaClasses javaClasses;
 
+    /**
+     * Ctor.
+     *
+     * @param archunitRule the ArchUnit rule to evaluate
+     * @param javaClasses  the classes to evaluate the rule against
+     */
     public AssertThatClassesFollowProvidedArchunitGuidelines(ArchRule archunitRule, JavaClasses javaClasses) {
         this.archunitRule = archunitRule;
         this.javaClasses = javaClasses;

--- a/oo-guidelines/guidelines-archunit/src/main/java/com/pragmaticobjects/oo/guidelines/archunit/archunit/assertions/AssertThatConcreteClassesAreNotFinal.java
+++ b/oo-guidelines/guidelines-archunit/src/main/java/com/pragmaticobjects/oo/guidelines/archunit/archunit/assertions/AssertThatConcreteClassesAreNotFinal.java
@@ -37,7 +37,19 @@ import static com.tngtech.archunit.core.domain.JavaClass.Predicates.RECORDS;
 import static com.tngtech.archunit.lang.conditions.ArchConditions.notBeFinal;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 
+/**
+ * Assertion that enforces the guideline that concrete classes must not be declared {@code final},
+ * allowing them to be subclassed for decoration or extension purposes.
+ *
+ * @author Kapralov Sergey
+ */
 public class AssertThatConcreteClassesAreNotFinal extends AssertThatClassesFollowProvidedArchunitGuidelines {
+    /**
+     * Ctor.
+     *
+     * @param javaClasses classes to check
+     * @param concretics  predicate identifying the concrete classes to enforce the rule on
+     */
     public AssertThatConcreteClassesAreNotFinal(
         JavaClasses javaClasses,
         DescribedPredicate<JavaClass> concretics

--- a/oo-guidelines/guidelines-archunit/src/main/java/com/pragmaticobjects/oo/guidelines/archunit/archunit/assertions/AssertThatConcreteClassesDeclareOnlyFinalFields.java
+++ b/oo-guidelines/guidelines-archunit/src/main/java/com/pragmaticobjects/oo/guidelines/archunit/archunit/assertions/AssertThatConcreteClassesDeclareOnlyFinalFields.java
@@ -35,7 +35,19 @@ import static com.tngtech.archunit.base.DescribedPredicate.not;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.ENUMS;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 
+/**
+ * Assertion that enforces the guideline that all fields of concrete classes must be declared
+ * {@code final}, ensuring immutability.
+ *
+ * @author Kapralov Sergey
+ */
 public class AssertThatConcreteClassesDeclareOnlyFinalFields extends AssertThatClassesFollowProvidedArchunitGuidelines {
+    /**
+     * Ctor.
+     *
+     * @param javaClasses classes to check
+     * @param concretics  predicate identifying the concrete classes to enforce the rule on
+     */
     public AssertThatConcreteClassesDeclareOnlyFinalFields(
         JavaClasses javaClasses,
         DescribedPredicate<JavaClass> concretics

--- a/oo-guidelines/guidelines-archunit/src/main/java/com/pragmaticobjects/oo/guidelines/archunit/archunit/assertions/AssertThatMethodsOfConcreteClassesDontCallConstructorsOfOtherConcretics.java
+++ b/oo-guidelines/guidelines-archunit/src/main/java/com/pragmaticobjects/oo/guidelines/archunit/archunit/assertions/AssertThatMethodsOfConcreteClassesDontCallConstructorsOfOtherConcretics.java
@@ -45,6 +45,12 @@ import static com.tngtech.archunit.lang.conditions.ArchConditions.callConstructo
 import static com.tngtech.archunit.lang.conditions.ArchPredicates.are;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 
+/**
+ * Assertion that enforces the guideline that non-static methods of concrete classes must not
+ * call constructors of other concrete classes (to avoid hidden side effects and coupling).
+ *
+ * @author Kapralov Sergey
+ */
 public class AssertThatMethodsOfConcreteClassesDontCallConstructorsOfOtherConcretics extends AssertThatClassesFollowProvidedArchunitGuidelines {
     private static DescribedPredicate<JavaClass> concretics(DescribedPredicate<JavaClass> concretics) {
         return and(
@@ -82,6 +88,12 @@ public class AssertThatMethodsOfConcreteClassesDontCallConstructorsOfOtherConcre
         );
     }
 
+    /**
+     * Ctor.
+     *
+     * @param javaClasses classes to check
+     * @param concretics  predicate identifying the concrete classes to enforce the rule on
+     */
     public AssertThatMethodsOfConcreteClassesDontCallConstructorsOfOtherConcretics(
         JavaClasses javaClasses,
         DescribedPredicate<JavaClass> concretics

--- a/oo-guidelines/guidelines-archunit/src/main/java/com/pragmaticobjects/oo/guidelines/archunit/archunit/conditions/BePrimaryConstructor.java
+++ b/oo-guidelines/guidelines-archunit/src/main/java/com/pragmaticobjects/oo/guidelines/archunit/archunit/conditions/BePrimaryConstructor.java
@@ -34,7 +34,16 @@ import static com.tngtech.archunit.core.domain.JavaClass.Predicates.type;
 import static com.tngtech.archunit.core.domain.JavaCodeUnit.Predicates.constructor;
 import static com.tngtech.archunit.core.domain.properties.HasModifiers.Predicates.modifier;
 
+/**
+ * ArchUnit condition that checks whether a constructor is a <em>primary constructor</em>:
+ * it may only assign {@code final} fields and call the {@link Object} super constructor.
+ *
+ * @author Kapralov Sergey
+ */
 public class BePrimaryConstructor extends DeepConstructorAnalysisCondition {
+    /**
+     * Ctor. Uses default exclusions (final field assignments and {@code Object} super call).
+     */
     public BePrimaryConstructor() {
         this(
             List.empty(),
@@ -42,6 +51,12 @@ public class BePrimaryConstructor extends DeepConstructorAnalysisCondition {
         );
     }
 
+    /**
+     * Ctor.
+     *
+     * @param additionalFieldAccessExclusions  extra field-access patterns allowed in a primary constructor
+     * @param additionalCtorCallsExclusion     extra constructor-call patterns allowed in a primary constructor
+     */
     public BePrimaryConstructor(
         List<FieldAccessExclusion> additionalFieldAccessExclusions,
         List<ConstructorCallsExclusion> additionalCtorCallsExclusion

--- a/oo-guidelines/guidelines-archunit/src/main/java/com/pragmaticobjects/oo/guidelines/archunit/archunit/conditions/BeSecondaryConstructor.java
+++ b/oo-guidelines/guidelines-archunit/src/main/java/com/pragmaticobjects/oo/guidelines/archunit/archunit/conditions/BeSecondaryConstructor.java
@@ -43,7 +43,19 @@ import static com.tngtech.archunit.core.domain.JavaClass.Predicates.type;
 import static com.tngtech.archunit.core.domain.JavaCodeUnit.Predicates.constructor;
 import static com.tngtech.archunit.core.domain.properties.HasModifiers.Predicates.modifier;
 
+/**
+ * ArchUnit condition that checks whether a constructor is a <em>secondary constructor</em>:
+ * it may delegate to other concrete class constructors, access static constants, use Vavr
+ * collections, and call certain safe static factory methods, but must not assign instance fields.
+ *
+ * @author Kapralov Sergey
+ */
 public class BeSecondaryConstructor extends DeepConstructorAnalysisCondition {
+    /**
+     * Ctor. Uses default exclusions.
+     *
+     * @param concretics predicate identifying concrete classes whose constructors are allowed targets
+     */
     public BeSecondaryConstructor(
         DescribedPredicate<JavaClass> concretics
     ) {
@@ -54,6 +66,13 @@ public class BeSecondaryConstructor extends DeepConstructorAnalysisCondition {
         );
     }
 
+    /**
+     * Ctor.
+     *
+     * @param concretics                        predicate identifying concrete classes whose constructors are allowed targets
+     * @param additionalFieldAccessExclusions   extra field-access patterns allowed in a secondary constructor
+     * @param additionalCtorCallsExclusions     extra constructor-call patterns allowed in a secondary constructor
+     */
     public BeSecondaryConstructor(
         DescribedPredicate<JavaClass> concretics,
         List<FieldAccessExclusion> additionalFieldAccessExclusions,

--- a/oo-guidelines/guidelines-archunit/src/main/java/com/pragmaticobjects/oo/guidelines/archunit/archunit/conditions/DeepConstructorAnalysisCondition.java
+++ b/oo-guidelines/guidelines-archunit/src/main/java/com/pragmaticobjects/oo/guidelines/archunit/archunit/conditions/DeepConstructorAnalysisCondition.java
@@ -33,11 +33,26 @@ import com.tngtech.archunit.lang.ConditionEvents;
 import com.tngtech.archunit.lang.SimpleConditionEvent;
 import io.vavr.collection.List;
 
+/**
+ * Base ArchUnit condition that analyses a constructor's field accesses and method calls,
+ * reporting violations for any that are not covered by the provided exclusion lists.
+ * Subclasses ({@link BePrimaryConstructor}, {@link BeSecondaryConstructor}) configure
+ * the allowed patterns.
+ *
+ * @author Kapralov Sergey
+ */
 public class DeepConstructorAnalysisCondition extends ArchCondition<JavaConstructor> {
     private final String constructorType;
     private final List<FieldAccessExclusion> fieldAccessExclusions;
     private final List<ConstructorCallsExclusion> ctorCallExclusion;
 
+    /**
+     * Ctor.
+     *
+     * @param constructorType    human-readable name of the constructor type (e.g. "primary")
+     * @param fieldAccessExclusions  patterns of field accesses that are permitted
+     * @param ctorCallExclusion      patterns of constructor/method calls that are permitted
+     */
     public DeepConstructorAnalysisCondition(String constructorType, List<FieldAccessExclusion> fieldAccessExclusions, List<ConstructorCallsExclusion> ctorCallExclusion) {
         super(constructorType + " constructor");
         this.constructorType = constructorType;

--- a/oo-guidelines/guidelines-archunit/src/main/java/com/pragmaticobjects/oo/guidelines/archunit/archunit/exclusions/ConstructorCallsExclusion.java
+++ b/oo-guidelines/guidelines-archunit/src/main/java/com/pragmaticobjects/oo/guidelines/archunit/archunit/exclusions/ConstructorCallsExclusion.java
@@ -29,10 +29,25 @@ import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaCodeUnit;
 
+/**
+ * Exclusion record that marks constructor or method calls as permitted within constructor
+ * analysis conditions. A call is excluded when both the owning class matches {@code owner}
+ * and the called code unit matches {@code target}.
+ *
+ * @author Kapralov Sergey
+ */
 public class ConstructorCallsExclusion {
+    /** Predicate that matches the class that owns the called code unit. */
     public final DescribedPredicate<JavaClass> owner;
+    /** Predicate that matches the called code unit (constructor or method). */
     public final DescribedPredicate<JavaCodeUnit> target;
 
+    /**
+     * Ctor.
+     *
+     * @param owner  predicate matching the class that owns the called code unit
+     * @param target predicate matching the called code unit itself
+     */
     public ConstructorCallsExclusion(
         DescribedPredicate<JavaClass> owner,
         DescribedPredicate<JavaCodeUnit> target

--- a/oo-guidelines/guidelines-archunit/src/main/java/com/pragmaticobjects/oo/guidelines/archunit/archunit/exclusions/FieldAccessExclusion.java
+++ b/oo-guidelines/guidelines-archunit/src/main/java/com/pragmaticobjects/oo/guidelines/archunit/archunit/exclusions/FieldAccessExclusion.java
@@ -28,9 +28,21 @@ package com.pragmaticobjects.oo.guidelines.archunit.archunit.exclusions;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaField;
 
+/**
+ * Exclusion record that marks field accesses as permitted within constructor analysis conditions.
+ * A field access is excluded when the accessed field matches the {@code field} predicate.
+ *
+ * @author Kapralov Sergey
+ */
 public class FieldAccessExclusion {
+    /** Predicate that matches fields whose access is permitted. */
     public final DescribedPredicate<JavaField> field;
 
+    /**
+     * Ctor.
+     *
+     * @param field predicate matching the fields whose access should be allowed
+     */
     public FieldAccessExclusion(
         DescribedPredicate<JavaField> field
     ) {

--- a/oo-guidelines/guidelines-archunit/src/main/java/com/pragmaticobjects/oo/guidelines/archunit/archunit/testsuite/GuidelinesTests.java
+++ b/oo-guidelines/guidelines-archunit/src/main/java/com/pragmaticobjects/oo/guidelines/archunit/archunit/testsuite/GuidelinesTests.java
@@ -37,9 +37,26 @@ import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import io.vavr.collection.List;
 
+/**
+ * JUnit 5 test suite that runs all standard architectural guideline checks powered by ArchUnit.
+ * Bundles rules for class finality, field finality, method finality, and constructor patterns.
+ *
+ * @author Kapralov Sergey
+ */
 public class GuidelinesTests extends TestsSuite {
+    /** Default predicate identifying concrete classes: all {@link EquivalenceCompliant} implementors. */
     public static DescribedPredicate<JavaClass> DEFAULT_CONCRETICS = JavaClass.Predicates.implement(EquivalenceCompliant.class);
 
+    /**
+     * Ctor.
+     *
+     * @param javaClasses                                        classes to check
+     * @param concretics                                         predicate identifying the concrete classes
+     * @param fieldAccessExclusionsAllowedInPrimaryConstructor   additional field-access exclusions for primary constructors
+     * @param callsAllowedInPrimaryConstructor                   additional call exclusions for primary constructors
+     * @param fieldAccessExclusionsAllowedInSecondaryConstructor additional field-access exclusions for secondary constructors
+     * @param callsAllowedInSecondaryConstructor                 additional call exclusions for secondary constructors
+     */
     public GuidelinesTests(
         JavaClasses javaClasses,
         DescribedPredicate<JavaClass> concretics,
@@ -82,6 +99,11 @@ public class GuidelinesTests extends TestsSuite {
         );
     }
 
+    /**
+     * Ctor. Uses {@link #DEFAULT_CONCRETICS} predicate and empty exclusion lists.
+     *
+     * @param javaClasses classes to check
+     */
     public GuidelinesTests(
         JavaClasses javaClasses
     ) {

--- a/oo-guidelines/guidelines-hints/src/main/java/com/pragmaticobjects/oo/guidelines/archunit/ArchitecturalExclusion.java
+++ b/oo-guidelines/guidelines-hints/src/main/java/com/pragmaticobjects/oo/guidelines/archunit/ArchitecturalExclusion.java
@@ -30,6 +30,12 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Marker annotation that excludes an annotated type, constructor, or method from the
+ * architectural guideline checks enforced by the {@code guidelines-archunit} module.
+ *
+ * @author Kapralov Sergey
+ */
 @Target({ElementType.TYPE, ElementType.CONSTRUCTOR, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ArchitecturalExclusion {

--- a/oo-inference/inference-basic/src/main/java/com/pragmaticobjects/oo/inference/codegen/model/InferredClassModel.java
+++ b/oo-inference/inference-basic/src/main/java/com/pragmaticobjects/oo/inference/codegen/model/InferredClassModel.java
@@ -33,7 +33,21 @@ import io.vavr.collection.HashMap;
 import java.util.Collection;
 
 
+/**
+ * Freemarker model for generating a concrete inferred implementation class.
+ * Exposes the generated class type, the target interface, and the list of methods
+ * to implement as template variables.
+ *
+ * @author Kapralov Sergey
+ */
 public class InferredClassModel extends FAMStandard {
+    /**
+     * Ctor.
+     *
+     * @param _this      the type being generated
+     * @param _interface the interface that the generated class implements
+     * @param _methods   the list of methods to delegate via inference
+     */
     public InferredClassModel(Type _this, Type _interface, Collection<Method> _methods) {
         super(
             _this,

--- a/oo-inference/inference-basic/src/main/java/com/pragmaticobjects/oo/inference/hack/Hacks.java
+++ b/oo-inference/inference-basic/src/main/java/com/pragmaticobjects/oo/inference/hack/Hacks.java
@@ -40,7 +40,23 @@ import java.util.Map;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+/**
+ * Utility class with workarounds for annotation processing limitations.
+ * In particular, accessing {@link Class} values from annotations during annotation processing
+ * requires catching {@link javax.lang.model.type.MirroredTypeException} to obtain the
+ * corresponding {@link TypeMirror}.
+ *
+ * @author Kapralov Sergey
+ */
 public class Hacks {
+    /**
+     * Extracts a {@link TypeMirror} from an annotation attribute that holds a {@link Class} reference.
+     * This works by provoking a {@link javax.lang.model.type.MirroredTypeException} and reading the
+     * type mirror from it.
+     *
+     * @param classSupplier supplier of the annotation's class attribute (e.g. {@code anno::value})
+     * @return the corresponding {@link TypeMirror}
+     */
     public static TypeMirror extractType(Supplier<Class<?>> classSupplier) {
         try {
             Class<?> clazz = classSupplier.get();

--- a/oo-inference/inference-codegen/src/main/java/com/pragmaticobjects/oo/inference/api/GenerateInferred.java
+++ b/oo-inference/inference-codegen/src/main/java/com/pragmaticobjects/oo/inference/api/GenerateInferred.java
@@ -30,9 +30,27 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Package-level annotation that instructs the annotation processor to generate an
+ * inferred implementation for the specified interface in the annotated package.
+ *
+ * @author Kapralov Sergey
+ */
 @Target(ElementType.PACKAGE)
 @Retention(RetentionPolicy.SOURCE)
 public @interface GenerateInferred {
+    /**
+     * The interface for which to generate an inferred implementation.
+     *
+     * @return the target interface class
+     */
     Class<?> value();
+
+    /**
+     * Optional custom name for the generated class.
+     * Defaults to {@code <InterfaceName>Inferred} when left empty.
+     *
+     * @return the desired class name, or empty string to use the default
+     */
     String className() default "";
 }

--- a/oo-inference/inference-itests/external-module/src/main/java/com/external/FracFixed.java
+++ b/oo-inference/inference-itests/external-module/src/main/java/com/external/FracFixed.java
@@ -25,10 +25,22 @@
  */
 package com.external;
 
+/**
+ * A fixed-value {@link Fraction} with constant numerator and denominator.
+ * Used as a test fixture for the inference integration tests.
+ *
+ * @author Kapralov Sergey
+ */
 public class FracFixed implements Fraction {
     private final int num;
     private final int denum;
 
+    /**
+     * Ctor.
+     *
+     * @param num   the numerator
+     * @param denum the denominator
+     */
     public FracFixed(int num, int denum) {
         this.num = num;
         this.denum = denum;

--- a/oo-inference/inference-itests/external-module/src/main/java/com/external/Fraction.java
+++ b/oo-inference/inference-itests/external-module/src/main/java/com/external/Fraction.java
@@ -25,7 +25,20 @@
  */
 package com.external;
 
+/**
+ * A mathematical fraction with a numerator and denominator.
+ * Used as a test fixture for the inference integration tests.
+ *
+ * @author Kapralov Sergey
+ */
 public interface Fraction {
+    /**
+     * @return the numerator of this fraction
+     */
     int numerator();
+
+    /**
+     * @return the denominator of this fraction
+     */
     int denumenator();
 }

--- a/oo-inference/inference-itests/external-module/src/main/java/com/external/FractionInferred.java
+++ b/oo-inference/inference-itests/external-module/src/main/java/com/external/FractionInferred.java
@@ -27,9 +27,20 @@ package com.external;
 
 import com.pragmaticobjects.oo.inference.api.Inference;
 
+/**
+ * Inferred {@link Fraction} implementation that delegates all calls to a provided
+ * {@link Inference} strategy. Used as a test fixture for the inference integration tests.
+ *
+ * @author Kapralov Sergey
+ */
 public class FractionInferred implements Fraction {
     private final Inference<Fraction> inference;
 
+    /**
+     * Ctor.
+     *
+     * @param inference the inference strategy that provides the actual {@link Fraction} instance
+     */
     public FractionInferred(Inference<Fraction> inference) {
         this.inference = inference;
     }

--- a/oo-memoized/memoized-tests/src/main/java/com/pragmaticobjects/oo/memoized/assertions/AssertCallTimes.java
+++ b/oo-memoized/memoized-tests/src/main/java/com/pragmaticobjects/oo/memoized/assertions/AssertCallTimes.java
@@ -32,11 +32,25 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import com.pragmaticobjects.oo.memoized.core.Memory;
 
+/**
+ * Assertion that verifies the number of times a {@link Memory} actually invokes the underlying
+ * callable when accessed multiple times. Memoization should cause the callable to be executed
+ * exactly once on repeated calls with the same key.
+ *
+ * @author Kapralov Sergey
+ */
 public class AssertCallTimes implements Assertion {
     private final Memory memory;
     private final int callNums;
     private final int expectedNumCalls;
 
+    /**
+     * Ctor.
+     *
+     * @param memory           the memory implementation under test
+     * @param callNums         how many times to call {@code memory.memoized(...)}
+     * @param expectedNumCalls the expected number of actual callable invocations
+     */
     public AssertCallTimes(Memory memory, int callNums, int expectedNumCalls) {
         this.memory = memory;
         this.callNums = callNums;

--- a/oo-memoized/memoized-tests/src/main/java/com/pragmaticobjects/oo/memoized/assertions/AssertDisposal.java
+++ b/oo-memoized/memoized-tests/src/main/java/com/pragmaticobjects/oo/memoized/assertions/AssertDisposal.java
@@ -33,12 +33,27 @@ import org.assertj.core.api.Assertions;
 
 import java.util.Optional;
 
+/**
+ * Assertion that verifies the behaviour of {@link Memory#dispose} — checking that it returns
+ * the expected value for a callable that was previously memoized, while other callables are
+ * first memoized as preparation.
+ *
+ * @author Kapralov Sergey
+ */
 public class AssertDisposal implements Assertion {
     private final Memory memoryUnderTest;
     private final List<MemoizedCallable<?>> preparationCallables;
     private final MemoizedCallable<?> callableToDispose;
     private final Optional<?> expectedDisposedValue;
 
+    /**
+     * Ctor.
+     *
+     * @param memoryUnderTest       the memory implementation under test
+     * @param preparationCallables  callables to memoize before the disposal check
+     * @param callableToDispose     the callable whose memoized value is to be disposed
+     * @param expectedDisposedValue the expected value returned by {@link Memory#dispose}
+     */
     public AssertDisposal(Memory memoryUnderTest, List<MemoizedCallable<?>> preparationCallables, MemoizedCallable<?> callableToDispose, Optional<?> expectedDisposedValue) {
         this.memoryUnderTest = memoryUnderTest;
         this.preparationCallables = preparationCallables;

--- a/oo-memoized/memoized-tests/src/main/java/com/pragmaticobjects/oo/memoized/assertions/TestCallable.java
+++ b/oo-memoized/memoized-tests/src/main/java/com/pragmaticobjects/oo/memoized/assertions/TestCallable.java
@@ -29,11 +29,22 @@ import com.pragmaticobjects.oo.memoized.core.MemoizedCallable;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
+/**
+ * Test-purpose {@link MemoizedCallable} that increments a counter each time it is invoked.
+ * Used by memoization assertions to verify call count behaviour.
+ *
+ * @author Kapralov Sergey
+ */
 // NOTE: equals, hashCode and toString are implicitly generated
 // by equivalence-maven-plugin
 class TestCallable implements MemoizedCallable {
     private final AtomicInteger counter;
 
+    /**
+     * Ctor.
+     *
+     * @param counter the counter incremented on each {@link #call()} invocation
+     */
     public TestCallable(AtomicInteger counter) {
         this.counter = counter;
     }

--- a/oo-meta/meta-model/src/main/java/com/pragmaticobjects/oo/meta/model/Generic.java
+++ b/oo-meta/meta-model/src/main/java/com/pragmaticobjects/oo/meta/model/Generic.java
@@ -25,6 +25,18 @@
  */
 package com.pragmaticobjects.oo.meta.model;
 
+/**
+ * Abstraction for a Java type's generic parameter (e.g. {@code T}, {@code ? extends Foo},
+ * {@code String}). Implementations produce the textual form used in generated source code
+ * and expose the imports they require.
+ *
+ * @author Kapralov Sergey
+ */
 public interface Generic extends ImportsProvider {
+    /**
+     * Returns the source-code representation of this generic parameter.
+     *
+     * @return generic parameter string (e.g. {@code "T"}, {@code "? extends Foo"})
+     */
     String asString();
 }

--- a/oo-meta/meta-model/src/main/java/com/pragmaticobjects/oo/meta/model/GenericBoundary.java
+++ b/oo-meta/meta-model/src/main/java/com/pragmaticobjects/oo/meta/model/GenericBoundary.java
@@ -25,6 +25,14 @@
  */
 package com.pragmaticobjects.oo.meta.model;
 
+/**
+ * Enum representing the bound kind of a wildcard generic type: {@code extends} or {@code super}.
+ *
+ * @author Kapralov Sergey
+ */
 public enum GenericBoundary {
-    EXTENDS, SUPER
+    /** Represents {@code ? extends T}. */
+    EXTENDS,
+    /** Represents {@code ? super T}. */
+    SUPER
 }

--- a/oo-meta/meta-model/src/main/java/com/pragmaticobjects/oo/meta/model/GenericEmpty.java
+++ b/oo-meta/meta-model/src/main/java/com/pragmaticobjects/oo/meta/model/GenericEmpty.java
@@ -28,6 +28,12 @@ package com.pragmaticobjects.oo.meta.model;
 import java.util.Collection;
 import java.util.Collections;
 
+/**
+ * {@link Generic} implementation that represents the absence of generic parameters,
+ * producing an empty string.
+ *
+ * @author Kapralov Sergey
+ */
 public class GenericEmpty implements Generic {
     @Override
     public final String asString() {

--- a/oo-meta/meta-model/src/main/java/com/pragmaticobjects/oo/meta/model/GenericFromTypeMirror.java
+++ b/oo-meta/meta-model/src/main/java/com/pragmaticobjects/oo/meta/model/GenericFromTypeMirror.java
@@ -29,7 +29,20 @@ import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.TypeVariable;
 import javax.lang.model.type.WildcardType;
 
+/**
+ * {@link Generic} implementation that infers the correct generic representation
+ * from a {@link javax.lang.model.type.TypeMirror} obtained during annotation processing.
+ * Dispatches to {@link GenericFromWildcardType}, {@link GenericFromTypeVariable},
+ * or {@link GenericType} based on the mirror's runtime kind.
+ *
+ * @author Kapralov Sergey
+ */
 public class GenericFromTypeMirror extends GenericInferred{
+    /**
+     * Ctor.
+     *
+     * @param typeMirror the type mirror to derive the generic representation from
+     */
     public GenericFromTypeMirror(TypeMirror typeMirror) {
         super(
             new Inference<Generic>() {

--- a/oo-meta/meta-model/src/main/java/com/pragmaticobjects/oo/meta/model/GenericFromTypeVariable.java
+++ b/oo-meta/meta-model/src/main/java/com/pragmaticobjects/oo/meta/model/GenericFromTypeVariable.java
@@ -29,9 +29,20 @@ import javax.lang.model.type.TypeVariable;
 import java.util.Collection;
 import java.util.Collections;
 
+/**
+ * {@link Generic} implementation backed by a {@link javax.lang.model.type.TypeVariable},
+ * producing the variable's name as its string representation.
+ *
+ * @author Kapralov Sergey
+ */
 public class GenericFromTypeVariable implements Generic {
     private final TypeVariable variable;
 
+    /**
+     * Ctor.
+     *
+     * @param variable the type variable to represent
+     */
     public GenericFromTypeVariable(TypeVariable variable) {
         this.variable = variable;
     }

--- a/oo-meta/meta-model/src/main/java/com/pragmaticobjects/oo/meta/model/GenericFromWildcardType.java
+++ b/oo-meta/meta-model/src/main/java/com/pragmaticobjects/oo/meta/model/GenericFromWildcardType.java
@@ -29,7 +29,19 @@ import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.WildcardType;
 import java.util.Objects;
 
+/**
+ * {@link Generic} implementation that builds a bounded wildcard ({@code ? extends T}
+ * or {@code ? super T}) from a {@link javax.lang.model.type.WildcardType} obtained
+ * during annotation processing.
+ *
+ * @author Kapralov Sergey
+ */
 public class GenericFromWildcardType extends GenericInferred {
+    /**
+     * Ctor.
+     *
+     * @param wildcard the wildcard type to derive the generic representation from
+     */
     public GenericFromWildcardType(WildcardType wildcard) {
         super(
             new Inference<Generic>() {

--- a/oo-meta/meta-model/src/main/java/com/pragmaticobjects/oo/meta/model/GenericInferred.java
+++ b/oo-meta/meta-model/src/main/java/com/pragmaticobjects/oo/meta/model/GenericInferred.java
@@ -27,9 +27,20 @@ package com.pragmaticobjects.oo.meta.model;
 
 import java.util.Collection;
 
+/**
+ * {@link Generic} implementation that lazily delegates to an {@link Inference} strategy,
+ * allowing the concrete generic type to be determined at call time.
+ *
+ * @author Kapralov Sergey
+ */
 public class GenericInferred implements Generic {
     private final Inference<Generic> inference;
 
+    /**
+     * Ctor.
+     *
+     * @param inference the strategy used to resolve the actual {@link Generic} instance
+     */
     public GenericInferred(Inference<Generic> inference) {
         this.inference = inference;
     }

--- a/oo-meta/meta-model/src/main/java/com/pragmaticobjects/oo/meta/model/GenericSequence.java
+++ b/oo-meta/meta-model/src/main/java/com/pragmaticobjects/oo/meta/model/GenericSequence.java
@@ -30,9 +30,20 @@ import io.vavr.collection.List;
 import java.util.Collection;
 import java.util.stream.Collectors;
 
+/**
+ * {@link Generic} implementation that joins multiple generic parameters into a
+ * comma-separated sequence (e.g. {@code K, V} for a two-parameter type).
+ *
+ * @author Kapralov Sergey
+ */
 public class GenericSequence implements Generic {
     private final List<Generic> generics;
 
+    /**
+     * Ctor.
+     *
+     * @param generics the list of generic parameters to join
+     */
     public GenericSequence(List<Generic> generics) {
         this.generics = generics;
     }

--- a/oo-meta/meta-model/src/main/java/com/pragmaticobjects/oo/meta/model/GenericType.java
+++ b/oo-meta/meta-model/src/main/java/com/pragmaticobjects/oo/meta/model/GenericType.java
@@ -29,9 +29,20 @@ import io.vavr.collection.List;
 
 import java.util.Collection;
 
+/**
+ * {@link Generic} implementation that wraps a concrete {@link Type}, using the type's
+ * declaration as the generic parameter string.
+ *
+ * @author Kapralov Sergey
+ */
 public class GenericType implements Generic {
     private final Type type;
 
+    /**
+     * Ctor.
+     *
+     * @param type the type to represent as a generic parameter
+     */
     public GenericType(Type type) {
         this.type = type;
     }

--- a/oo-meta/meta-model/src/main/java/com/pragmaticobjects/oo/meta/model/GenericWildcard.java
+++ b/oo-meta/meta-model/src/main/java/com/pragmaticobjects/oo/meta/model/GenericWildcard.java
@@ -27,10 +27,22 @@ package com.pragmaticobjects.oo.meta.model;
 
 import java.util.Collection;
 
+/**
+ * {@link Generic} implementation representing a bounded wildcard such as
+ * {@code ? extends Foo} or {@code ? super Bar}.
+ *
+ * @author Kapralov Sergey
+ */
 public class GenericWildcard implements Generic {
     private final GenericBoundary boundaryType;
     private final Generic boundary;
 
+    /**
+     * Ctor.
+     *
+     * @param boundaryType whether the wildcard uses {@code extends} or {@code super}
+     * @param boundary     the generic representing the bound type
+     */
     public GenericWildcard(GenericBoundary boundaryType, Generic boundary) {
         this.boundaryType = boundaryType;
         this.boundary = boundary;

--- a/oo-tests/tests-core/src/main/java/com/pragmaticobjects/oo/tests/AssertCombined.java
+++ b/oo-tests/tests-core/src/main/java/com/pragmaticobjects/oo/tests/AssertCombined.java
@@ -28,16 +28,27 @@ package com.pragmaticobjects.oo.tests;
 import io.vavr.collection.List;
 
 /**
+ * Assertion that combines several assertions, checking each one in order.
  *
- * @author skapral
+ * @author Kapralov Sergey
  */
 public class AssertCombined implements Assertion {
     private final List<Assertion> assertions;
 
+    /**
+     * Ctor.
+     *
+     * @param assertions List of assertions to combine
+     */
     public AssertCombined(List<Assertion> assertions) {
         this.assertions = assertions;
     }
-    
+
+    /**
+     * Ctor.
+     *
+     * @param assertions Assertions to combine
+     */
     public AssertCombined(Assertion... assertions) {
         this(List.of(assertions));
     }

--- a/oo-tests/tests-junit4/src/main/java/com/pragmaticobjects/oo/tests/junit4/TestRunner.java
+++ b/oo-tests/tests-junit4/src/main/java/com/pragmaticobjects/oo/tests/junit4/TestRunner.java
@@ -30,9 +30,19 @@ import org.junit.runner.Description;
 import org.junit.runner.Runner;
 import org.junit.runner.notification.RunNotifier;
 
+/**
+ * JUnit 4 runner that executes {@link JUnit4TestsSuite} test cases.
+ *
+ * @author Kapralov Sergey
+ */
 public class TestRunner extends Runner {
     private final Class<JUnit4TestsSuite> testClass;
 
+    /**
+     * Ctor.
+     *
+     * @param testClass Test suite class to run
+     */
     public TestRunner(Class<JUnit4TestsSuite> testClass) {
         super();
         this.testClass = testClass;


### PR DESCRIPTION
## Summary

- Added English-language Javadoc to every interface and class in all main source modules
- Class/interface-level: description + `@author Kapralov Sergey`
- Constructors: `@param` tags for non-obvious parameters
- Public/protected methods: `@param`, `@return`, `@throws` where applicable
- Verified with `mvn javadoc:aggregate` — no warnings or errors

## Modules covered

- `oo-tests` — `AssertCombined`, `TestRunner`
- `oo-equivalence/equivalence-base` — `EquivalenceLogic`, `HintedAttribute`, `tostring/*`, annotations
- `oo-equivalence/equivalence-assertions` — `AssertImplements*`
- `oo-equivalence/equivalence-codegen` — `IIImplementEObject*`
- `oo-equivalence/equivalence-itests` — all test-fixture classes
- `oo-memoized/memoized-tests` — `AssertCallTimes`, `AssertDisposal`, `TestCallable`
- `oo-meta/meta-model` — `Generic`, `GenericBoundary`, and all `Generic*` implementations
- `oo-inference` — `GenerateInferred`, `Hacks`, `InferredClassModel`, external-module fixtures
- `oo-guidelines` — `ArchitecturalExclusion`, all archunit assertions, conditions, and exclusions

## Test plan

- [ ] `mvn javadoc:aggregate` completes without warnings or errors
- [ ] No logic changes — diff is documentation-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)